### PR TITLE
Update to the released embedded-hal version 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/andelf/embedded-drivers"
 [dependencies]
 nb = "1"
 embedded-hal-02 = { package = "embedded-hal", version = "0.2", features = ["unproven"] }
-embedded-hal-1 = {  package = "embedded-hal", version = "1.0.0-alpha.10" }
+embedded-hal-1 = {  package = "embedded-hal", version = "1.0" }
 num-traits = { version = "0.2.15", default-features = false, features = ["libm"] }
 defmt = { version = "0.3", optional = true }
 embedded-graphics-framebuf = "0.2.0"

--- a/src/bh1750.rs
+++ b/src/bh1750.rs
@@ -1,4 +1,4 @@
-use embedded_hal_1::{delay::DelayUs, i2c::I2c};
+use embedded_hal_1::{delay::DelayNs, i2c::I2c};
 
 /// BH1750 Ambient Light Sensor(ALS)
 ///
@@ -53,7 +53,7 @@ where
         self.i2c
     }
 
-    pub fn init(&mut self, config: Config, delay: &mut impl DelayUs) -> Result<(), I2C::Error> {
+    pub fn init(&mut self, config: Config, delay: &mut impl DelayNs) -> Result<(), I2C::Error> {
         // power on
         self.i2c.write(self.address, &[0x01])?;
         // defaults to Continuously H-Resolution Mode

--- a/src/bme280.rs
+++ b/src/bme280.rs
@@ -6,7 +6,7 @@
 //! Pressure resolution: 0.18 Pa
 //! Temperature resolution: 0.01 C
 
-use embedded_hal_1::delay::DelayUs;
+use embedded_hal_1::delay::DelayNs;
 use embedded_hal_1::i2c::I2c;
 
 #[cfg(feature = "serde")]
@@ -270,7 +270,7 @@ where
     }
 
     /// Initializes the BME280
-    pub fn init<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    pub fn init<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         self.verify_chip_id()?;
         self.soft_reset(delay)?;
         self.calibrate()?;
@@ -291,7 +291,7 @@ where
         }
     }
 
-    fn soft_reset<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    fn soft_reset<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         self.write_register(BME280_RESET_ADDR, BME280_SOFT_RESET_CMD)?;
         delay.delay_ms(2); // startup time is 2ms
         Ok(())
@@ -304,7 +304,7 @@ where
         Ok(())
     }
 
-    fn configure<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    fn configure<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         match self.mode()? {
             SensorMode::Sleep => {}
             _ => self.soft_reset(delay)?,
@@ -342,11 +342,11 @@ where
         }
     }
 
-    fn forced<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    fn forced<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         self.set_mode(BME280_FORCED_MODE, delay)
     }
 
-    fn set_mode<D: DelayUs>(&mut self, mode: u8, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    fn set_mode<D: DelayNs>(&mut self, mode: u8, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         match self.mode()? {
             SensorMode::Sleep => {}
             _ => self.soft_reset(delay)?,
@@ -357,7 +357,7 @@ where
     }
 
     /// Captures and processes sensor data for temperature, pressure, and humidity
-    pub fn measure<D: DelayUs>(&mut self, delay: &mut D) -> Result<Measurements, Error<I2C::Error>> {
+    pub fn measure<D: DelayNs>(&mut self, delay: &mut D) -> Result<Measurements, Error<I2C::Error>> {
         self.forced(delay)?;
         delay.delay_ms(40); // await measurement
         let measurements = self.read_data(BME280_DATA_ADDR)?;

--- a/src/ds1302.rs
+++ b/src/ds1302.rs
@@ -1,5 +1,5 @@
 use embedded_hal_1::{
-    delay::DelayUs,
+    delay::DelayNs,
     digital::{InputPin, OutputPin},
 };
 
@@ -8,7 +8,7 @@ pub trait InOutPin {
     type Output: OutputPin;
     fn set_output(&mut self);
     fn set_input(&mut self);
-    fn as_input(&self) -> &Self::Input;
+    fn as_input(&mut self) -> &mut Self::Input;
     fn as_output(&mut self) -> &mut Self::Output;
 }
 
@@ -33,7 +33,7 @@ where
         ThreeWire { ce, io, clk }
     }
 
-    fn read_byte(&mut self, delay: &mut impl DelayUs) -> u8 {
+    fn read_byte(&mut self, delay: &mut impl DelayNs) -> u8 {
         let mut byte = 0u8;
         for i in 0..8 {
             byte |= (self.io.as_input().is_high().unwrap() as u8) << i;
@@ -45,7 +45,7 @@ where
         byte
     }
 
-    fn write_byte(&mut self, byte: u8, delay: &mut impl DelayUs) {
+    fn write_byte(&mut self, byte: u8, delay: &mut impl DelayNs) {
         for i in 0..8 {
             if (byte >> i) & 1 != 0 {
                 self.io.as_output().set_high().unwrap();
@@ -60,7 +60,7 @@ where
         }
     }
 
-    pub fn read_reg(&mut self, addr: u8, delay: &mut impl DelayUs) -> u8 {
+    pub fn read_reg(&mut self, addr: u8, delay: &mut impl DelayNs) -> u8 {
         self.ce.set_high().unwrap();
         self.io.set_output();
         delay.delay_us(10_u32);
@@ -73,7 +73,7 @@ where
         out
     }
 
-    pub fn write_reg(&mut self, addr: u8, val: u8, delay: &mut impl DelayUs) {
+    pub fn write_reg(&mut self, addr: u8, val: u8, delay: &mut impl DelayNs) {
         self.ce.set_high().unwrap();
         self.io.set_output();
         delay.delay_us(10_u32);
@@ -87,7 +87,7 @@ where
     /// Hour 0-23
     /// Minute 0-59
     /// Second 0-59
-    pub fn read_hms(&mut self, delay: &mut impl DelayUs) -> (u8, u8, u8) {
+    pub fn read_hms(&mut self, delay: &mut impl DelayNs) -> (u8, u8, u8) {
         let mut h = self.read_reg(0x85, delay);
         let mut m = self.read_reg(0x83, delay);
         let mut s = self.read_reg(0x81, delay);
@@ -105,7 +105,7 @@ where
     /// Year 0-99
     /// Month 1-12
     /// Day 1-31
-    pub fn read_ymd(&mut self, delay: &mut impl DelayUs) -> (u8, u8, u8) {
+    pub fn read_ymd(&mut self, delay: &mut impl DelayNs) -> (u8, u8, u8) {
         let mut y = self.read_reg(0x8d, delay);
         let mut m = self.read_reg(0x89, delay);
         let mut d = self.read_reg(0x87, delay);
@@ -121,22 +121,22 @@ where
     }
 
     /// Weekday 1-7
-    pub fn read_day(&mut self, delay: &mut impl DelayUs) -> u8 {
+    pub fn read_day(&mut self, delay: &mut impl DelayNs) -> u8 {
         let day = self.read_reg(0x8b, delay);
         day
     }
 
-    pub fn set_hms(&mut self, h: u8, m: u8, s: u8, delay: &mut impl DelayUs) {
+    pub fn set_hms(&mut self, h: u8, m: u8, s: u8, delay: &mut impl DelayNs) {
         self.write_reg(0x84, ((h / 10) << 4) | (h % 10), delay);
         self.write_reg(0x82, ((m / 10) << 4) | (m % 10), delay);
         self.write_reg(0x80, ((s / 10) << 4) | (s % 10), delay);
     }
-    pub fn set_ymd<D: DelayUs>(&mut self, y: u8, m: u8, d: u8, delay: &mut impl DelayUs) {
+    pub fn set_ymd<D: DelayNs>(&mut self, y: u8, m: u8, d: u8, delay: &mut impl DelayNs) {
         self.write_reg(0x8c, ((y / 10) << 4) | (y % 10), delay);
         self.write_reg(0x88, ((m / 10) << 4) | (m % 10), delay);
         self.write_reg(0x86, ((d / 10) << 4) | (d % 10), delay);
     }
-    pub fn set_day<D: DelayUs>(&mut self, day: u8, delay: &mut impl DelayUs) {
+    pub fn set_day<D: DelayNs>(&mut self, day: u8, delay: &mut impl DelayNs) {
         if day >= 1 && day <= 7 {
             self.write_reg(0x8a, day, delay);
         }


### PR DESCRIPTION
A simple update to eh 1.0.
I needed this to test the BME280 with a ssd1306 on my ch32v307 board, in order to use `embedded-hal-bus`.
I have only tested the BM280 sensor but the changes should work for the other sensors.
![IMG_20240414_182848_small](https://github.com/andelf/embedded-drivers/assets/8845664/aa07cfb9-1216-4849-91b6-a668ab1a4cdd)

```rust
#![no_std]
#![no_main]
#![feature(type_alias_impl_trait)]

use ch32_hal as hal;
use core::cell::RefCell;
use embassy_executor::Spawner;
use embassy_time::{Delay, Duration, Timer};
use embedded_drivers::bme280;
use embedded_graphics::{
    mono_font::{iso_8859_1::FONT_6X10, MonoTextStyleBuilder},
    pixelcolor::BinaryColor,
    prelude::*,
    text::{Alignment, Baseline, Text},
};
use embedded_hal_bus::i2c;
use hal::dma::NoDma;
use hal::gpio::{AnyPin, Level, Output, Pin, Speed};
use hal::i2c::I2c;
use hal::println;
use hal::time::Hertz;
use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};

#[embassy_executor::main(entry = "qingke_rt::entry")]
async fn main(spawner: Spawner) -> ! {
    hal::debug::SDIPrint::enable();
    let p = hal::init(hal::Config::default());
    hal::embassy::init();

    let i2c_sda = p.PB7;
    let i2c_scl = p.PB6;

    println!("init ok");

    let i2c = I2c::new(
        p.I2C1,
        i2c_scl,
        i2c_sda,
        NoDma,
        NoDma,
        Hertz::khz(100),
        Default::default(),
    );

    let i2c_ref_cell = RefCell::new(i2c);
    let i2c_dev = i2c::RefCellDevice::new(&i2c_ref_cell);
    let mut bme280 = bme280::BME280::new_primary(i2c_dev);

    if let Err(e) = bme280.init(&mut Delay) {
        println!("Failed to init the BME280 sensor: {:?}", e);
        loop {
            Timer::after_millis(2000).await;
        }
    }

    let i2c_dev = i2c::RefCellDevice::new(&i2c_ref_cell);
    let interface = I2CDisplayInterface::new(i2c_dev);
    let mut display =
        Ssd1306::new(interface, DisplaySize128x32, DisplayRotation::Rotate0).into_buffered_graphics_mode();
    display.init().unwrap();

    // GPIO
    spawner.spawn(blink(p.PA3.degrade())).unwrap();

    let text_style = MonoTextStyleBuilder::new()
        .font(&FONT_6X10)
        .text_color(BinaryColor::On)
        .build();

    Text::with_alignment(
        "SSD1306 + BME280 demo",
        display.bounding_box().center(),
        text_style,
        Alignment::Center,
    )
    .draw(&mut display)
    .unwrap();

    display.flush().unwrap();

    Timer::after_millis(1000).await;

    display.clear(BinaryColor::Off).unwrap();

    loop {
        display.clear(BinaryColor::Off).unwrap();
        match bme280.measure(&mut Delay) {
            Ok(meas) => {
                println!("Temp: {:.2}°C", meas.temperature);
                println!("Hum: {:.2} %", meas.humidity);
                println!("Press: {:.2} kPa", meas.pressure / 1000.0_f32);

                let mut buf = [0u8; 64];
                let s = format_no_std::show(&mut buf, format_args!("Temp: {:.2} °C", meas.temperature)).unwrap();

                Text::with_baseline(s, Point::new(0, 0), text_style, Baseline::Top)
                    .draw(&mut display)
                    .unwrap();

                let mut buf = [0u8; 64];
                let s = format_no_std::show(&mut buf, format_args!("Hum: {:.2} %", meas.humidity)).unwrap();

                Text::with_baseline(s, Point::new(0, 11), text_style, Baseline::Top)
                    .draw(&mut display)
                    .unwrap();

                let mut buf = [0u8; 64];
                let s = format_no_std::show(&mut buf, format_args!("Press: {:.2} kPa", meas.pressure / 1000.0_f32))
                    .unwrap();

                Text::with_baseline(s, Point::new(0, 22), text_style, Baseline::Top)
                    .draw(&mut display)
                    .unwrap();
            }
            Err(e) => {
                println!("Error in measure: {:?}", e);

                Text::with_baseline("Error reading sensor", Point::new(0, 22), text_style, Baseline::Top)
                    .draw(&mut display)
                    .unwrap();
            }
        }

        display.flush().unwrap();

        Timer::after_millis(2000).await;
    }
}

#[panic_handler]
fn panic(info: &core::panic::PanicInfo) -> ! {
    let _ = println!("\n\n\n{}", info);

    loop {}
}

#[embassy_executor::task]
async fn blink(pin: AnyPin) {
    let mut led = Output::new(pin, Level::Low, Speed::Low);

    loop {
        led.set_high();
        Timer::after(Duration::from_millis(1000)).await;
        led.set_low();
        Timer::after(Duration::from_millis(1000)).await;
    }
}
```